### PR TITLE
chore: bump vib to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # vib-gh-action
+
 GitHub Action to build a Vib image and optionally push it on a registry
 
 ## Usage
+
 See [action.yml](action.yml)
 
 ```yaml
 steps:
   - uses: actions/checkout@v4
-  - uses: vanilla-os/vib-gh-action@v0.3.3-1
+  - uses: vanilla-os/vib-gh-action@v0.5.0
     with:
       recipe: 'myRecipe.yml'
       plugins: org/repo:tag,org/repo:tag
@@ -16,6 +18,7 @@ steps:
 default `recipe` value is `recipe.yml`, default `plugins` value is empty.
 
 ## References
+
 - [Vib](https://github.com/Vanilla-OS/Vib)
 - [Vib plugins](https://github.com/Vanilla-OS/vib-plugin)
 - [Vib image example](https://github.com/Vanilla-OS/desktop-image)

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VIB_VERSION="0.3.3"
+VIB_VERSION="0.5.0"
 PLUGINS_ARG="${1:-}"
 
 if [ -z "$PLUGINS_ARG" ]; then


### PR DESCRIPTION
After merging this PR, a release must be made for the new version.