### PR TITLE
chore: bump to v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See [action.yml](action.yml)
 ```yml
 steps:
   - uses: actions/checkout@v4
-  - uses: vanilla-os/vib-gh-action@v0.8.1
+  - uses: vanilla-os/vib-gh-action@v1.0.0
     with:
       recipe: 'myRecipe.yml'
       plugins: org/repo:tag,org/repo:tag

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VIB_VERSION="0.8.1"
+VIB_VERSION="1.0.0"
 PLUGINS_ARG="${1:-}"
 
 wget "https://github.com/Vanilla-OS/Vib/releases/download/v$VIB_VERSION/plugins.tar.xz"


### PR DESCRIPTION
Bump the used vib version to 1.0.0