### PR TITLE
feat: adds containerfile input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,11 @@ inputs:
     description: 'List of plugins to use'
     required: false
     default: ''
+  output:
+    description: 'Path to Containerfile'
+    required: false
+    default: 'Containerfile'
+
 runs:
   using: 'composite'
   steps:
@@ -23,4 +28,4 @@ runs:
 
     - name: Run Vib
       shell: bash
-      run: ./vib build ${{ inputs.recipe }}
+      run: ./vib build --output ${{ inputs.output }} ${{ inputs.recipe }}


### PR DESCRIPTION
This change exposes the --output <Containerfile> flag in the GH Action.

This is useful for building multiple variations of one custom image in the same repo.